### PR TITLE
fix: update repository URLs to reflect correct ownership and versioning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ Before creating an issue, please:
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/yourusername/BlazorSignalStore.git
+   git clone https://github.com/TempooDev/BlazorSignalStore.git
    cd BlazorSignalStore
    ```
 
@@ -127,7 +127,7 @@ dotnet format
 ## Getting Help
 
 - Check the [documentation](docs/)
-- Look through existing [issues](https://github.com/yourusername/BlazorSignalStore/issues)
+- Look through existing [issues](https://github.com/TempooDev/BlazorSignalStore/issues)
 - Create a new issue with the question label
 
 ## Recognition

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,12 +13,11 @@
     <Company>BlazorSignalStore</Company>
     <Copyright>Copyright © 2025 BlazorSignalStore Contributors</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/yourusername/BlazorSignalStore</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/yourusername/BlazorSignalStore.git</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/TempooDev/BlazorSignalStore</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/TempooDev/BlazorSignalStore.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>blazor;signalr;state-management;realtime;nuget</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageIcon>icon.png</PackageIcon>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     
     <!-- Source Link -->
@@ -28,7 +27,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     
     <!-- Version will be set by CI/CD pipeline -->
-    <Version>1.0.0</Version>
+    <Version>0.1.0</Version>
     <PackageVersion>$(Version)</PackageVersion>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>

--- a/docs/README.md
+++ b/docs/README.md
@@ -96,8 +96,8 @@ This includes:
 ## Getting Help
 
 - 📖 **Documentation**: Browse these docs for detailed information
-- 🐛 **Issues**: Report bugs or request features on [GitHub Issues](https://github.com/yourusername/BlazorSignalStore/issues)
-- 💬 **Discussions**: Ask questions in [GitHub Discussions](https://github.com/yourusername/BlazorSignalStore/discussions)
+- 🐛 **Issues**: Report bugs or request features on [GitHub Issues](https://github.com/TempooDev/BlazorSignalStore/issues)
+- 💬 **Discussions**: Ask questions in [GitHub Discussions](https://github.com/TempooDev/BlazorSignalStore/discussions)
 - 📧 **Email**: Contact the maintainers for private questions
 
 ## Contributing


### PR DESCRIPTION
This pull request updates project metadata and documentation to reflect the new GitHub repository location under the `TempooDev` organization. It also updates the package version to `0.1.0`. These changes ensure consistency across documentation, project files, and package metadata.

Repository and documentation updates:

* Updated all GitHub URLs in `CONTRIBUTING.md` and `docs/README.md` to reference `TempooDev/BlazorSignalStore` instead of `yourusername/BlazorSignalStore`, ensuring links point to the correct repository. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L59-R59) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L130-R130) [[3]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L99-R100)

Project metadata changes:

* Changed `PackageProjectUrl` and `RepositoryUrl` in `Directory.Build.props` to use the new `TempooDev` organization URLs.
* Updated the package `Version` from `1.0.0` to `0.1.0` in `Directory.Build.props`, reflecting the current development stage.